### PR TITLE
PyOperator to upload txt Moron file to S3

### DIFF
--- a/dags/.gitignore
+++ b/dags/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.pyc
+.env

--- a/dags/dag_universidad_f.py
+++ b/dags/dag_universidad_f.py
@@ -1,11 +1,36 @@
 from datetime import timedelta, datetime
 import logging
-
+import os
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
+from airflow.operators.python import PythonOperator
+from decouple import config
+import boto3
+from botocore.exceptions import ClientError
 
 logging.basicConfig(level=logging.INFO, datefmt='%Y-%m-%d', format='%(asctime)s - %(name)s - %(message)s')
 logger = logging.getLogger('univ_f')
+
+def upload_moron_s3():
+    # S3 credential
+    bucket_name = config('BUCKET_NAME')
+    # S3 Client
+    s3 = boto3.client('s3',
+        aws_access_key_id = config('AWS_ACCESS_KEY_ID'),
+        aws_secret_access_key = config('AWS_SECRET_ACCESS_KEY'))
+
+    # Folder path
+    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    # Upload Moron file to S3
+    
+    try:
+        with open(f'{root_dir}/txt/moron.txt', 'rb') as file:
+            s3.upload_fileobj(file, bucket_name, 'S3_moron.txt')
+    except ClientError as e:
+        print('Error: ',e)
+        return False
+    return True
+
 
 default_args = {
     "retries": 5,  # try 5 times
@@ -23,4 +48,6 @@ with DAG(
     tarea2 = DummyOperator(task_id='Query_F2') #Universidad de Río Cuarto
     tarea3 = DummyOperator(task_id='Processing_data')#Reading and processing data using read_sql
     tarea4 = DummyOperator(task_id='Upload_S3')#uploading data to s3
-    [tarea1, tarea2] >> tarea3 >> tarea4
+    upload_s3_moron = PythonOperator(task_id='upload_s3_moron',python_callable=upload_moron_s3)
+
+    [tarea1, tarea2] >> tarea3 >> [tarea4, upload_s3_moron]

--- a/template.env
+++ b/template.env
@@ -1,0 +1,11 @@
+# Database credentials
+DB_USER = 
+DB_PASSWORD = 
+DB_HOST = 
+DB_PORT = 
+DB_NAME = 
+
+# S3 credentials (AWS))
+BUCKET_NAME = 
+PUBLIC KEY = 
+SECRET KEY = 


### PR DESCRIPTION
Resumen:
 - Agregué las credenciales a .env y agregué .env a .gitignore
 - Agregué el nombre de las variables en template.env
 - Creé la función upload_moron_s3(), que se encarga de subir el archivo moron.txt al repositorio S3 (AWS).
 - Agergué un PythonOperator que ejecuta dicha función

[Link a la tarea en Jira](https://alkemy-labs.atlassian.net/browse/OT152-290?atlOrigin=eyJpIjoiNGMzYWI4MWNhZjczNDhiMzhkNTY1NGY2YjI2OGNkZjAiLCJwIjoiaiJ9)